### PR TITLE
#37: [sub-issues] prettifier adds duplicate fields (closes #37)

### DIFF
--- a/src/processors/subIssues.js
+++ b/src/processors/subIssues.js
@@ -19,17 +19,18 @@ function updateIssueBody(repoName, body, issue) {
 function generateListItem({ state, title, number }) {
   const isOpen = state === 'open';
   return {
-    type: 'list',
-    body: [
-      {
-        type: 'listitem',
-        text: [ `[${isOpen ? ' ' : 'x'}] ${title.replace(/\[[^\]]+\]/, '').trim()} #${number}` ]
-      }
-    ],
-    ordered: false
+    type: 'listitem',
+    text: [ `[${isOpen ? ' ' : 'x'}] ${title.replace(/\[[^\]]+\]/, '').trim()} #${number}` ]
   };
 }
 
+function generateList(issue) {
+  return {
+    type: 'list',
+    body: [generateListItem(issue)],
+    ordered: false
+  };
+}
 
 function patchSubIssuesParagraph(macroIssue, subIssue) {
   const shouldReplaceListItem = (listItem) => find(listItem.text, x => includes(x, `#${subIssue.number}`));
@@ -62,7 +63,7 @@ function generateSubIssuesParagraph(macroIssue, subIssue) {
   };
 
   const visitors = {
-    onEndWithNoTransformation: () => [ subIssuesHeader, [ generateListItem(subIssue)] ]
+    onEndWithNoTransformation: () => [ subIssuesHeader, [ generateList(subIssue)] ]
   };
 
   return mdRenderer(macroIssue.body || '', visitors);


### PR DESCRIPTION
Issue #37

**test plan**
1) create first sub-issue --> sub-issues paragraph correctly added to macro issue

2) edit sub-issue of macro issues with many sub-issues:
- correctly edited
- no empty line added

3) edit again same/adiacent issue
- correctly edited
- no empty line added