### PR TITLE
#60: [hophop] integrate events from `hophop`  (closes #60)

### DIFF
--- a/config-ci.json
+++ b/config-ci.json
@@ -13,5 +13,9 @@
       "topicLabels": ["web", "api", "escalapio", "documentation", "iOS", "QIA IS", "QIA OD", "omnilab-feedback"],
       "delay": 10000
     }
-  }
+  },
+  "platforms": [
+    "github",
+    "hophop"
+  ]
 }

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,8 @@ const Config = t.struct({
       topicLabels: t.list(t.String),
       delay: t.Number
     })
-  })
+  }),
+  platforms: t.list(t.String)
 }, 'Config');
 
 export default Config(configJSON);

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,12 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 import Rx from 'rx';
+import { find } from 'lodash';
 import processors from './processors';
 import { isEvent } from './validators';
+import config from './config';
 
+const platforms = config.platforms.map(p => `x-${p}-event`);
 const subject = new Rx.Subject();
 
 const onNext = (event, delay) => {
@@ -18,11 +21,14 @@ const app = express();
 app.use(bodyParser.json());
 
 app.post('/', ({ body, headers }, res) => {
-  const event = headers['x-github-event'];
+  const event = headers[find(platforms, p => headers[p])];
 
-  onNext({ event, body });
-
-  res.send('👍');
+  if (event) {
+    onNext({ event, body });
+    res.send('👍');
+  } else {
+    res.status(403).send('Forbidden');
+  }
 });
 
 app.listen(3000);

--- a/src/validators.js
+++ b/src/validators.js
@@ -47,8 +47,18 @@ const TopicReminderEvent = t.struct({
   body: Issue
 });
 
+const HophopEvent = t.struct({
+  event: t.refinement(t.String, s => startsWith(s, 'hophop-')),
+  body: t.struct({
+    issue: t.maybe(t.Object),
+    pull_request: t.maybe(t.Object),
+    repository: t.Object
+  })
+});
+
 export const isEvent = x => isStruct(Event, x);
 export const isPullRequestEvent = x => isStruct(PullRequestEvent, x);
 export const isIssueEvent = x => isStruct(IssueEvent, x);
 export const isReminderEvent = x => isStruct(ReminderEvent, x);
 export const isTopicReminderEvent = x => isStruct(TopicReminderEvent, x);
+export const isHophopEvent = x => isStruct(HophopEvent, x);


### PR DESCRIPTION
Issue #60 

**test plan**
- resend standard github event --> prettifier worked as usual
- send event with `x-hophop-event: ""` --> prettifier returns :+1: (accepted platform)
- send event with `x-wrong-event: ""` --> prettifier returns 403
- send event with:
  - `x-hophop-event: "hophop-issues"`
  - `body: { issue: { number: 60 }, repository: { name: 'github-prettifier' } }`
  - **output** --> @nemobot correctly adds label WIP to #60 

![image](https://cloud.githubusercontent.com/assets/4029499/14388638/475f42b4-fdaf-11e5-82e8-aa61447be6cd.png)
![image](https://cloud.githubusercontent.com/assets/4029499/14388651/56bb9a32-fdaf-11e5-870d-904f2634f4ed.png)
